### PR TITLE
Add base16-tmux theme swap functionality which mimics base16-vim theme switching feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 See the [Base16 repository](https://github.com/base16-project/base16) for more information.
 These scripts were built with [base16-builder-python](https://github.com/InspectorMustache/base16-builder-python).
 
-A shell script to change your shell's default ANSI colors but most importantly, colors 17 to 21 of your shell's 256 colorspace (if supported by your terminal). This script makes it possible to honor the original bright colors of your shell (e.g. bright green is still green and so on) while providing additional base16 colors to applications such as Vim.
+A shell script to change your shell's default ANSI colors but most importantly, colors 17 to 21 of your shell's 256 colorspace (if supported by your terminal). This script makes it possible to honor the original bright colors of your shell (e.g. bright green is still green and so on) while providing additional base16 colors to applications such as Vim and tmux.
 
 ![Base16 Shell](/screenshots/base16-shell.png)
 
@@ -51,7 +51,7 @@ Open a new shell and type `base16` followed by a tab to perform tab completion.
 
 ### Base16-Vim Users
 
-the profile_helper will update a ~/.vimrc_background file that will have your current the colorscheme, you just need to source this file in your vimrc: i.e. (remove the base16colorspace line if not needed)
+This section is for [base16-vim](https://github.com/base16-project/base16-vim) users. The `profile_helper` will update a `~/.vimrc_background` file that will have your current colorscheme, you just need to source this file in your `.vimrc`: i.e. 
 
 ```shell
 if filereadable(expand("~/.vimrc_background"))
@@ -59,6 +59,17 @@ if filereadable(expand("~/.vimrc_background"))
   source ~/.vimrc_background
 endif
 ```
+Remove the base16colorspace line if not needed.
+
+### Base16-Tmux Users
+
+This section is for [base16-tmux](https://github.com/mattdavis90/base16-tmux) users. The `profile_helper` will update a `~/.tmux.base16.conf` file that will have your current colorscheme, you just need to source this file in your `.tmux.conf`: i.e.
+
+```
+source-file ~/.tmux.base16.conf
+```
+
+Make sure to reload your `~/.tmux.conf` file after the theme has been updated through `profile_helper`.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Open a new shell and type `base16` followed by a tab to perform tab completion.
 
 ### Base16-Vim Users
 
-This section is for [base16-vim](https://github.com/base16-project/base16-vim) users. The `profile_helper` will update a `~/.vimrc_background` file that will have your current colorscheme, you just need to source this file in your `.vimrc`: i.e. 
+This section is for [base16-vim](https://github.com/base16-project/base16-vim) users. base16-shell will update (or create) the  `~/.vimrc_background` file and set the colorscheme. You need to source this file in your `.vimrc`. You can do this by adding the following to your `.vimrc`:
 
 ```shell
 if filereadable(expand("~/.vimrc_background"))
@@ -59,11 +59,11 @@ if filereadable(expand("~/.vimrc_background"))
   source ~/.vimrc_background
 endif
 ```
-Remove the base16colorspace line if not needed.
+Remove the base16colorspace line if it is not needed.
 
 ### Base16-Tmux Users
 
-This section is for [base16-tmux](https://github.com/mattdavis90/base16-tmux) users. The `profile_helper` will update a `~/.tmux.base16.conf` file that will have your current colorscheme, you just need to source this file in your `.tmux.conf`: i.e.
+This section is for [base16-tmux](https://github.com/mattdavis90/base16-tmux) users. base16-shell will update (or create) the `~/.tmux.base16.conf` file and set the colorscheme. You need to source this file in your `.tmux.conf`. You can do this by adding the following to your `.tmux.conf`:
 
 ```
 source-file ~/.tmux.base16.conf

--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -28,6 +28,9 @@ for SCRIPT in $SCRIPT_DIR/scripts/*.sh
     sh $SCRIPT
     ln -sf $SCRIPT ~/.base16_theme
     set -gx BASE16_THEME (string split -m 1 '-' $THEME)[2]
+    if test -e ~/.tmux/plugins/base16-tmux
+      echo "set -g @colors-base16 '$THEME'" > ~/.tmux.base16.conf
+    end
     echo -e "if !exists('g:colors_name') || g:colors_name != '$THEME'\n  colorscheme $THEME\nendif" >  ~/.vimrc_background
     if test (count $BASE16_SHELL_HOOKS) -eq 1; and test -d "$BASE16_SHELL_HOOKS"
       for hook in $BASE16_SHELL_HOOKS/*

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -21,6 +21,7 @@ _base16()
   [ -f $script ] && . $script
   ln -fs $script ~/.base16_theme
   export BASE16_THEME=${theme}
+  if [ -e ~/.tmux/plugins/base16-tmux ]; then echo -e "set -g \0100colors-base16 '$theme'" >| ~/.tmux.base16.conf; fi;
   echo -e "if \0041exists('g:colors_name') || g:colors_name != 'base16-$theme'\n  colorscheme base16-$theme\nendif" >| ~/.vimrc_background
   if [ -n ${BASE16_SHELL_HOOKS:+s} ] && [ -d "${BASE16_SHELL_HOOKS}" ]; then
     for hook in $BASE16_SHELL_HOOKS/*; do


### PR DESCRIPTION
Add functionality for base16-tmux which basically mimics what is happening for base16-vim. Currently when I swap a theme I need to manually update the base16-tmux theme in my `.tmux.conf` file. This adds functionality which updates a `.tmux.base16.conf` file, every time a base16-shell theme is switched, that base16-tmux users can source in their `.tmux.conf`.

Also update the vim instructions in the readme to be more easily understandable.