### PR TITLE
Update var names and config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ as Vim and tmux.
 
 ```shell
 git clone https://github.com/base16-project/base16-shell.git \
-  ~/.config/base16-shell
+  $HOME/.config/base16-shell
 ```
 
 ### Bash/ZSH
 
-Add following lines to `~/.bashrc` or `~/.zshrc`:
+Add following lines to `.bashrc` or `.zshrc`:
 
 ```bash
 # Base16 Shell
-BASE16_SHELL="$HOME/.config/base16-shell/"
+BASE16_SHELL="$HOME/.config/base16-shell"
 [ -n "$PS1" ] && \
   [ -s "$BASE16_SHELL/profile_helper.sh" ] && \
     source "$BASE16_SHELL/profile_helper.sh"
@@ -53,12 +53,12 @@ To use it, add `base16-shell` to the plugins array in your `.zshrc` file:
 
 ### Fish
 
-Add following lines to `~/.config/fish/config.fish`:
+Add following lines to `$HOME/.config/fish/config.fish`:
 
 ```fish
 # Base16 Shell
 if status --is-interactive
-  set BASE16_SHELL "$HOME/.config/base16-shell/"
+  set BASE16_SHELL "$HOME/.config/base16-shell"
   source "$BASE16_SHELL/profile_helper.fish"
 end
 ```
@@ -103,15 +103,15 @@ end
 ### Base16-Tmux Users
 
 This section is for [base16-tmux][3] users. base16-shell will update (or
-create) the `~/.tmux.base16.conf` file and set the colorscheme. You need
-to source this file in your `.tmux.conf`. You can do this by adding the
-following to your `.tmux.conf`:
+create) the `$HOME/.tmux.base16.conf` file and set the colorscheme. You
+need to source this file in your `.tmux.conf`. You can do this by adding
+the following to your `.tmux.conf`:
 
 ```
-source-file ~/.tmux.base16.conf
+source-file $HOME/.tmux.base16.conf
 ```
 
-Make sure to reload your `~/.tmux.conf` file after the theme has been
+Make sure to reload your `.tmux.conf` file after the theme has been
 updated through `profile_helper`.
 
 ### Keeping your themes up to date

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Add following lines to `.bashrc` or `.zshrc`:
 
 ```bash
 # Base16 Shell
-BASE16_SHELL="$HOME/.config/base16-shell"
+BASE16_SHELL_PATH="$HOME/.config/base16-shell"
 [ -n "$PS1" ] && \
-  [ -s "$BASE16_SHELL/profile_helper.sh" ] && \
-    source "$BASE16_SHELL/profile_helper.sh"
+  [ -s "$BASE16_SHELL_PATH/profile_helper.sh" ] && \
+    source "$BASE16_SHELL_PATH/profile_helper.sh"
 ```
 
 ### Oh my zsh
@@ -58,8 +58,8 @@ Add following lines to `$HOME/.config/fish/config.fish`:
 ```fish
 # Base16 Shell
 if status --is-interactive
-  set BASE16_SHELL "$HOME/.config/base16-shell"
-  source "$BASE16_SHELL/profile_helper.fish"
+  set BASE16_SHELL_PATH "$HOME/.config/base16-shell"
+  source "$BASE16_SHELL_PATH/profile_helper.fish"
 end
 ```
 
@@ -103,12 +103,12 @@ end
 ### Base16-Tmux Users
 
 This section is for [base16-tmux][3] users. base16-shell will update (or
-create) the `$HOME/.tmux.base16.conf` file and set the colorscheme. You
-need to source this file in your `.tmux.conf`. You can do this by adding
-the following to your `.tmux.conf`:
+create) the `$HOME/.config/base16-project/tmux.base16.conf` file and
+set the colorscheme. You need to source this file in your `.tmux.conf`.
+You can do this by adding the following to your `.tmux.conf`:
 
 ```
-source-file $HOME/.tmux.base16.conf
+source-file $HOME/.config/base16-project/tmux.base16.conf
 ```
 
 Make sure to reload your `.tmux.conf` file after the theme has been

--- a/base16-shell.plugin.bash
+++ b/base16-shell.plugin.bash
@@ -1,5 +1,6 @@
 script_path=${BASH_SOURCE[0]}
 script_path=$(readlink -f $script_path)
-BASE16_SHELL=${script_path%/*}
+BASE16_SHELL_PATH=${script_path%/*}
 
-[ -n "$PS1" ] && [ -s $BASE16_SHELL/profile_helper.sh ] && source "$BASE16_SHELL/profile_helper.sh"
+[ -n "$PS1" ] && [ -s $BASE16_SHELL_PATH/profile_helper.sh ] && source \
+  "$BASE16_SHELL_PATH/profile_helper.sh"

--- a/base16-shell.plugin.zsh
+++ b/base16-shell.plugin.zsh
@@ -1,5 +1,6 @@
 script_path=${(%):-%x}
 script_path=$(readlink -f $script_path)
-BASE16_SHELL=${script_path%/*}
+BASE16_SHELL_PATH=${script_path%/*}
 
-[ -n "$PS1" ] && [ -s $BASE16_SHELL/profile_helper.sh ] && source "$BASE16_SHELL/profile_helper.sh"
+[ -n "$PS1" ] && [ -s $BASE16_SHELL_PATH/profile_helper.sh ] && source \
+  "$BASE16_SHELL_PATH/profile_helper.sh"

--- a/colortest
+++ b/colortest
@@ -62,5 +62,5 @@ for padded_value in `seq -w 0 21`; do
   printf "%s %s %s %-30s %s\x1b[0m\n" $foreground $base16_color_name $current_color_label ${ansi_label:-""} $block
 done;
 if [ $# -eq 1 ]; then
-    printf "To restore current theme, source ~/.base16_theme or reopen your terminal\n"
+    printf "To restore current theme, source $HOME/.base16_theme or reopen your terminal\n"
 fi

--- a/colortest
+++ b/colortest
@@ -62,5 +62,5 @@ for padded_value in `seq -w 0 21`; do
   printf "%s %s %s %-30s %s\x1b[0m\n" $foreground $base16_color_name $current_color_label ${ansi_label:-""} $block
 done;
 if [ $# -eq 1 ]; then
-    printf "To restore current theme, source $HOME/.base16_theme or reopen your terminal\n"
+    printf "To restore current theme, source $HOME/.config/base16-project/base16_theme or reopen your terminal\n"
 fi

--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -1,8 +1,8 @@
 #!/usr/bin/env fish
 
-# [what] provides aliases for base16 themes and sets ~/.base16_theme
+# [what] provides aliases for base16 themes and sets $HOME/.base16_theme
 #
-# [usage] can be added to ~/.config/fish/config.fish like so:
+# [usage] can be added to $HOME/.config/fish/config.fish like so:
 #
 # if status --is-interactive
 #    source $HOME/.config/base16-shell/profile_helper.fish
@@ -16,13 +16,13 @@ if test -z $BASE16_SHELL
 end
 
 # load currently active theme...
-if test -e ~/.base16_theme
-  eval sh ~/.base16_theme
+if test -e "$HOME/.base16_theme"
+  eval sh "$HOME/.base16_theme"
 end
 
-if test -n "$BASE16_DEFAULT_THEME"; and not test -e ~/.base16_theme
+if test -n "$BASE16_DEFAULT_THEME"; and not test -e "$HOME/.base16_theme"
   ln -s "$BASE16_SHELL/scripts/base16-$BASE16_DEFAULT_THEME.sh" \
-    ~/.base16_theme
+    "$HOME/.base16_theme"
 end
 
 # set aliases, like base16_*...
@@ -31,10 +31,10 @@ for SCRIPT in $BASE16_SHELL/scripts/*.sh
   function $THEME -V SCRIPT -V THEME
     set partial_theme_name (string replace -a 'base16-' '' $THEME) # eg: ocean
     sh $SCRIPT
-    ln -sf $SCRIPT ~/.base16_theme
+    ln -sf $SCRIPT "$HOME/.base16_theme"
     set -gx BASE16_THEME (string split -m 1 '-' $THEME)[2]
-    if test -e ~/.tmux/plugins/base16-tmux
-      echo "set -g @colors-base16 '$partial_theme_name'" > ~/.tmux.base16.conf
+    if test -e "$HOME/.tmux/plugins/base16-tmux"
+      echo "set -g @colors-base16 '$partial_theme_name'" > "$HOME/.tmux.base16.conf"
     end
     if test (count $BASE16_SHELL_HOOKS) -eq 1; and test -d "$BASE16_SHELL_HOOKS"
       for hook in $BASE16_SHELL_HOOKS/*
@@ -44,4 +44,6 @@ for SCRIPT in $BASE16_SHELL/scripts/*.sh
   end
 end
 
-alias reset "command reset && [ -f ~/.base16_theme ] && sh ~/.base16_theme"
+alias reset "command reset \
+  && [ -f "$HOME/.base16_theme" ] \
+  && sh "$HOME/.base16_theme""

--- a/profile_helper.fish
+++ b/profile_helper.fish
@@ -1,6 +1,7 @@
 #!/usr/bin/env fish
 
-# [what] provides aliases for base16 themes and sets $HOME/.base16_theme
+# [what] provides aliases for base16 themes and sets
+# $HOME/.config/base16-project/base16_shell_theme
 #
 # [usage] can be added to $HOME/.config/fish/config.fish like so:
 #
@@ -10,32 +11,38 @@
 #
 # TODO: maybe port to $HOME/.config/fish/functions ?
 
+set BASE16_CONFIG_PATH "$HOME/.config/base16-project"
+set BASE16_SHELL_COLORSCHEME_PATH "$BASE16_CONFIG_PATH/base16_shell_theme"
+set BASE16_SHELL_TMUXCONF_PATH "$BASE16_CONFIG_PATH/tmux.base16.conf"
+set BASE16_TMUX_PLUGIN_PATH "$HOME/.tmux/plugins/base16-tmux"
 
-if test -z $BASE16_SHELL
-  set -g BASE16_SHELL (cd (dirname (status -f)); and pwd)
+
+if test -z $BASE16_SHELL_PATH
+  set -g BASE16_SHELL_PATH (cd (dirname (status -f)); and pwd)
 end
 
-# load currently active theme...
-if test -e "$HOME/.base16_theme"
-  eval sh "$HOME/.base16_theme"
+# Load the active theme
+if test -e $BASE16_SHELL_COLORSCHEME_PATH
+  sh $BASE16_SHELL_COLORSCHEME_PATH
 end
 
-if test -n "$BASE16_DEFAULT_THEME"; and not test -e "$HOME/.base16_theme"
-  ln -s "$BASE16_SHELL/scripts/base16-$BASE16_DEFAULT_THEME.sh" \
-    "$HOME/.base16_theme"
+if test -n "$BASE16_THEME_DEFAULT"; and not test -e $BASE16_SHELL_COLORSCHEME_PATH
+  ln -s "$BASE16_SHELL_PATH/scripts/base16-$BASE16_THEME_DEFAULT.sh" \
+    $BASE16_SHELL_COLORSCHEME_PATH
 end
 
-# set aliases, like base16_*...
-for SCRIPT in $BASE16_SHELL/scripts/*.sh
-  set THEME (basename $SCRIPT .sh) # eg: base16-ocean
+# Set base16-* aliases
+for SCRIPT in $BASE16_SHELL_PATH/scripts/*.sh
+  set THEME (basename $SCRIPT .sh)
   function $THEME -V SCRIPT -V THEME
     set partial_theme_name (string replace -a 'base16-' '' $THEME) # eg: ocean
     sh $SCRIPT
-    ln -sf $SCRIPT "$HOME/.base16_theme"
-    set -gx BASE16_THEME (string split -m 1 '-' $THEME)[2]
-    if test -e "$HOME/.tmux/plugins/base16-tmux"
-      echo "set -g @colors-base16 '$partial_theme_name'" > "$HOME/.tmux.base16.conf"
+    ln -sf $SCRIPT $BASE16_SHELL_COLORSCHEME_PATH
+    # If base16-tmux is used, provide a file to source when the theme changes
+    if test -e "$BASE16_TMUX_PLUGIN_PATH"
+      echo "set -g @colors-base16 '$partial_theme_name'" > "$BASE16_SHELL_TMUXCONF_PATH"
     end
+
     if test (count $BASE16_SHELL_HOOKS) -eq 1; and test -d "$BASE16_SHELL_HOOKS"
       for hook in $BASE16_SHELL_HOOKS/*
         test -f "$hook"; and test -x "$hook"; and "$hook"
@@ -45,5 +52,5 @@ for SCRIPT in $BASE16_SHELL/scripts/*.sh
 end
 
 alias reset "command reset \
-  && [ -f "$HOME/.base16_theme" ] \
-  && sh "$HOME/.base16_theme""
+  && [ -f $BASE16_SHELL_COLORSCHEME_PATH ] \
+  && sh $BASE16_SHELL_COLORSCHEME_PATH"

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -15,8 +15,8 @@ _base16()
   local script=$1
   local theme=$2
   [ -f "$script" ] && . $script
-  ln -fs "$script" ~/.base16_theme
-  if [ -e ~/.tmux/plugins/base16-tmux ]; then echo -e "set -g \0100colors-base16 '$theme'" >| ~/.tmux.base16.conf; fi;
+  ln -fs "$script" "$HOME/.base16_theme"
+  if [ -e "$HOME/.tmux/plugins/base16-tmux" ]; then echo -e "set -g \0100colors-base16 '$theme'" >| ~/.tmux.base16.conf; fi;
   if [ -n ${BASE16_SHELL_HOOKS:+s} ] && [ -d "${BASE16_SHELL_HOOKS}" ]; then
     for hook in $BASE16_SHELL_HOOKS/*; do
       [ -f "$hook" ] && [ -x "$hook" ] && "$hook"
@@ -24,13 +24,15 @@ _base16()
   fi
 }
 
-if [ -n "$BASE16_DEFAULT_THEME" ] && [ ! -e ~/.base16_theme ]; then
-  ln -s "$BASE16_SHELL/scripts/base16-$BASE16_DEFAULT_THEME.sh" \
-    ~/.base16_theme
+if [ -n "$BASE16_DEFAULT_THEME" ] \
+  && [ ! -e "$HOME/.base16_theme" ]; then
+  ln -s \
+    "$BASE16_SHELL_PATH/scripts/base16-$BASE16_DEFAULT_THEME.sh" \
+    "$HOME/.base16_theme"
 fi
 
-if [ -e ~/.base16_theme ]; then
-  . ~/.base16_theme
+if [ -e "$HOME/.base16_theme" ]; then
+  . "$HOME/.base16_theme"
 fi
 
 # Set base16_* aliases
@@ -42,4 +44,4 @@ for script in "$BASE16_SHELL"/scripts/base16*.sh; do
   alias $func_name="_base16 \"${script}\" ${theme}"
 done;
 
-alias reset="command reset && [ -f ~/.base16_theme ] && . ~/.base16_theme"
+alias reset="command reset && [ -f $HOME/.base16_theme ] && . $HOME/.base16_theme"

--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 
-if [ -z "$BASE16_SHELL" ]; then
+BASE16_CONFIG_PATH="$HOME/.config/base16-project"
+BASE16_SHELL_COLORSCHEME_PATH="$BASE16_CONFIG_PATH/base16_shell_theme"
+BASE16_SHELL_TMUXCONF_PATH="$BASE16_CONFIG_PATH/tmux.base16.conf"
+BASE16_TMUX_PLUGIN_PATH="$HOME/.tmux/plugins/base16-tmux"
+
+if [ ! -d "$BASE16_CONFIG_PATH" ]; then
+  mkdir -p "$BASE16_CONFIG_PATH"
+fi
+
+if [ -z "$BASE16_SHELL_PATH" ]; then
   if [ -n "$BASH_VERSION" ]; then
     script_path=${BASH_SOURCE[0]}
   elif [ -n "$ZSH_VERSION" ]; then
     script_path=${(%):-%x}
   fi
 
-  BASE16_SHELL=${script_path%/*}
+  BASE16_SHELL_PATH=${script_path%/*}
 fi
 
 _base16()
@@ -15,28 +24,36 @@ _base16()
   local script=$1
   local theme=$2
   [ -f "$script" ] && . $script
-  ln -fs "$script" "$HOME/.base16_theme"
-  if [ -e "$HOME/.tmux/plugins/base16-tmux" ]; then echo -e "set -g \0100colors-base16 '$theme'" >| ~/.tmux.base16.conf; fi;
-  if [ -n ${BASE16_SHELL_HOOKS:+s} ] && [ -d "${BASE16_SHELL_HOOKS}" ]; then
+  ln -fs $script "$BASE16_SHELL_COLORSCHEME_PATH"
+
+  # If base16-tmux is used, provide a file to source when the theme
+  # changes
+  if [ -e "$BASE16_TMUX_PLUGIN_PATH" ]; then 
+    echo -e "set -g \0100colors-base16 '$theme'" >| \
+      "$BASE16_SHELL_TMUXCONF_PATH"
+  fi
+
+  if [ -n ${BASE16_SHELL_HOOKS:+s} ] \
+    && [ -d "${BASE16_SHELL_HOOKS}" ]; then
     for hook in $BASE16_SHELL_HOOKS/*; do
       [ -f "$hook" ] && [ -x "$hook" ] && "$hook"
     done
   fi
 }
 
-if [ -n "$BASE16_DEFAULT_THEME" ] \
-  && [ ! -e "$HOME/.base16_theme" ]; then
+if [ -n "$BASE16_THEME_DEFAULT" ] \
+  && [ ! -e "$BASE16_SHELL_COLORSCHEME_PATH" ]; then
   ln -s \
-    "$BASE16_SHELL_PATH/scripts/base16-$BASE16_DEFAULT_THEME.sh" \
-    "$HOME/.base16_theme"
+    "$BASE16_SHELL_PATH/scripts/base16-$BASE16_THEME_DEFAULT.sh" \
+    "$BASE16_SHELL_COLORSCHEME_PATH"
 fi
 
-if [ -e "$HOME/.base16_theme" ]; then
-  . "$HOME/.base16_theme"
+if [ -e "$BASE16_SHELL_COLORSCHEME_PATH" ]; then
+  . "$BASE16_SHELL_COLORSCHEME_PATH"
 fi
 
 # Set base16_* aliases
-for script in "$BASE16_SHELL"/scripts/base16*.sh; do
+for script in "$BASE16_SHELL_PATH"/scripts/base16*.sh; do
   script_name=${script##*/}
   script_name=${script_name%.sh}
   theme=${script_name#*-}
@@ -44,4 +61,6 @@ for script in "$BASE16_SHELL"/scripts/base16*.sh; do
   alias $func_name="_base16 \"${script}\" ${theme}"
 done;
 
-alias reset="command reset && [ -f $HOME/.base16_theme ] && . $HOME/.base16_theme"
+alias reset="command reset \
+  && [ -f $BASE16_SHELL_COLORSCHEME_PATH ] \
+  && . $BASE16_SHELL_COLORSCHEME_PATH"


### PR DESCRIPTION
**Update shell paths to use variables to make it easier to update them and see what's going on**
- `BASE16_DEFAULT_THEME` -> `BASE16_THEME_DEFAULT` - (public) to stick to the `BASE16_THEME` prefix which already exists. This way we can expand on `BASE16_THEME_*` in future if we'd like to. This isn't backward compatible but the change introducing this was released less than an hour before this PR was created. I wanted to leave as much of the previous PR intact as possible since it was authored years ago.
- `BASE16_SHELL` -> `BASE16_SHELL_PATH` - (public) to be explicit about the nature of the variable. The script now determines this value automatically so the change is backward compatible;
- Introduce `BASE16_SHELL_COLORSCHEME_PATH`(private) since the path is used several times.

**Use `~/.config/base16-project` for config files. The idea here is to use this anytime we need to create any config file so we don't clutter the users home environment (like we do now).**
- `~/.base16_shell` -> `~/.config/base16-project/.base16_shell_theme`
- `~/.tmux.base16.conf` -> `~/.config/base16-project/.tmux.base16.conf`
